### PR TITLE
re-write plugin for new biography index format

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 Creates the alphabetical index pages for the biographies of the Maths History
 website.
 
-Biographies can be tagged in zero or more letters, and they will then
-appear on the corresponding alphabetical index page.
-
-Requires the `tags` widget to be added to Lektor GUI - currently this must be
-added manually.
+Biographies can be added to multiple index pages, by specifying multiple lines
+in the field in the Lektor Admin GUI. Each line in the field represents an index
+page, and will be normalized, and displayed.

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     packages=find_packages(),
     py_modules=['lektor_mathshistory_biographyindex'],
     url='https://github.com/mathshistory/mathshistory-biographyindex',
-    version='0.1.0',
+    version='1.0.0',
     classifiers=[
         'Framework :: Lektor',
         'Environment :: Plugins',


### PR DESCRIPTION
The alphabetical tagging system of the indexes has been replaced with a more flexible system that allows the customisation of how the mathematician's name appears on the index. For more info, see the README of this repo, or look at how to edit the indexes on the Maths History site internal wiki.